### PR TITLE
#181: Select extension of exported qr code

### DIFF
--- a/assets/i18n/strings.i18n.json
+++ b/assets/i18n/strings.i18n.json
@@ -311,6 +311,11 @@
       "Q": "Q (25%)",
       "H": "H (30%)"
     },
-    "test_before_use": "Always test a QR code before using it"
+    "test_before_use": "Always test a QR code before using it",
+    "export_type": {
+      "png": "PNG",
+      "jpg": "JPG",
+      "svg": "SVG"
+    }
   }
 }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 222
+/// Strings: 225
 ///
-/// Built on 2025-03-01 at 10:57 UTC
+/// Built on 2025-03-01 at 21:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -461,6 +461,8 @@ class _StringsQrCodeEn {
   late final _StringsQrCodeCorrectionLevelEn correctionLevel =
       _StringsQrCodeCorrectionLevelEn._(_root);
   String get testBeforeUse => 'Always test a QR code before using it';
+  late final _StringsQrCodeExportTypeEn exportType =
+      _StringsQrCodeExportTypeEn._(_root);
 }
 
 // Path: common.dayOfWeek
@@ -751,6 +753,18 @@ class _StringsQrCodeCorrectionLevelEn {
   String get m => 'M (15%)';
   String get q => 'Q (25%)';
   String get h => 'H (30%)';
+}
+
+// Path: qrCode.exportType
+class _StringsQrCodeExportTypeEn {
+  _StringsQrCodeExportTypeEn._(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+  String get png => 'PNG';
+  String get jpg => 'JPG';
+  String get svg => 'SVG';
 }
 
 // Path: cron.cronFormat.minutes
@@ -1326,6 +1340,12 @@ extension on Translations {
         return 'H (30%)';
       case 'qrCode.testBeforeUse':
         return 'Always test a QR code before using it';
+      case 'qrCode.exportType.png':
+        return 'PNG';
+      case 'qrCode.exportType.jpg':
+        return 'JPG';
+      case 'qrCode.exportType.svg':
+        return 'SVG';
       default:
         return null;
     }

--- a/lib/tools/qr_code/feature/effect/qr_code_effect.dart
+++ b/lib/tools/qr_code/feature/effect/qr_code_effect.dart
@@ -1,6 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:qr/qr.dart';
 
+import '../state/qr_code_state.dart';
+
 part 'qr_code_effect.freezed.dart';
 
 @freezed
@@ -8,5 +10,6 @@ part 'qr_code_effect.freezed.dart';
 sealed class QrCodeEffect with _$QrCodeEffect {
   const factory QrCodeEffect.saveToFile({
     required QrCode code,
+    required ExportType exportType,
   }) = SaveToFileEffect;
 }

--- a/lib/tools/qr_code/feature/effect/qr_code_effect.freezed.dart
+++ b/lib/tools/qr_code/feature/effect/qr_code_effect.freezed.dart
@@ -17,19 +17,20 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$QrCodeEffect {
   QrCode get code => throw _privateConstructorUsedError;
+  ExportType get exportType => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(QrCode code) saveToFile,
+    required TResult Function(QrCode code, ExportType exportType) saveToFile,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(QrCode code)? saveToFile,
+    TResult? Function(QrCode code, ExportType exportType)? saveToFile,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(QrCode code)? saveToFile,
+    TResult Function(QrCode code, ExportType exportType)? saveToFile,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -63,7 +64,7 @@ abstract class $QrCodeEffectCopyWith<$Res> {
           QrCodeEffect value, $Res Function(QrCodeEffect) then) =
       _$QrCodeEffectCopyWithImpl<$Res, QrCodeEffect>;
   @useResult
-  $Res call({QrCode code});
+  $Res call({QrCode code, ExportType exportType});
 }
 
 /// @nodoc
@@ -82,12 +83,17 @@ class _$QrCodeEffectCopyWithImpl<$Res, $Val extends QrCodeEffect>
   @override
   $Res call({
     Object? code = null,
+    Object? exportType = null,
   }) {
     return _then(_value.copyWith(
       code: null == code
           ? _value.code
           : code // ignore: cast_nullable_to_non_nullable
               as QrCode,
+      exportType: null == exportType
+          ? _value.exportType
+          : exportType // ignore: cast_nullable_to_non_nullable
+              as ExportType,
     ) as $Val);
   }
 }
@@ -100,7 +106,7 @@ abstract class _$$SaveToFileEffectImplCopyWith<$Res>
       __$$SaveToFileEffectImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({QrCode code});
+  $Res call({QrCode code, ExportType exportType});
 }
 
 /// @nodoc
@@ -117,12 +123,17 @@ class __$$SaveToFileEffectImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? code = null,
+    Object? exportType = null,
   }) {
     return _then(_$SaveToFileEffectImpl(
       code: null == code
           ? _value.code
           : code // ignore: cast_nullable_to_non_nullable
               as QrCode,
+      exportType: null == exportType
+          ? _value.exportType
+          : exportType // ignore: cast_nullable_to_non_nullable
+              as ExportType,
     ));
   }
 }
@@ -130,14 +141,16 @@ class __$$SaveToFileEffectImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$SaveToFileEffectImpl implements SaveToFileEffect {
-  const _$SaveToFileEffectImpl({required this.code});
+  const _$SaveToFileEffectImpl({required this.code, required this.exportType});
 
   @override
   final QrCode code;
+  @override
+  final ExportType exportType;
 
   @override
   String toString() {
-    return 'QrCodeEffect.saveToFile(code: $code)';
+    return 'QrCodeEffect.saveToFile(code: $code, exportType: $exportType)';
   }
 
   @override
@@ -145,11 +158,13 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SaveToFileEffectImpl &&
-            (identical(other.code, code) || other.code == code));
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.exportType, exportType) ||
+                other.exportType == exportType));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, code);
+  int get hashCode => Object.hash(runtimeType, code, exportType);
 
   /// Create a copy of QrCodeEffect
   /// with the given fields replaced by the non-null parameter values.
@@ -163,27 +178,27 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(QrCode code) saveToFile,
+    required TResult Function(QrCode code, ExportType exportType) saveToFile,
   }) {
-    return saveToFile(code);
+    return saveToFile(code, exportType);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(QrCode code)? saveToFile,
+    TResult? Function(QrCode code, ExportType exportType)? saveToFile,
   }) {
-    return saveToFile?.call(code);
+    return saveToFile?.call(code, exportType);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(QrCode code)? saveToFile,
+    TResult Function(QrCode code, ExportType exportType)? saveToFile,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
-      return saveToFile(code);
+      return saveToFile(code, exportType);
     }
     return orElse();
   }
@@ -218,11 +233,14 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
 }
 
 abstract class SaveToFileEffect implements QrCodeEffect {
-  const factory SaveToFileEffect({required final QrCode code}) =
-      _$SaveToFileEffectImpl;
+  const factory SaveToFileEffect(
+      {required final QrCode code,
+      required final ExportType exportType}) = _$SaveToFileEffectImpl;
 
   @override
   QrCode get code;
+  @override
+  ExportType get exportType;
 
   /// Create a copy of QrCodeEffect
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/tools/qr_code/feature/message/qr_code_message.dart
+++ b/lib/tools/qr_code/feature/message/qr_code_message.dart
@@ -13,4 +13,7 @@ sealed class QrCodeMessage with _$QrCodeMessage {
       ErrorCorrectionLevel level) = UpdateCorrectionLevelMessage;
 
   const factory QrCodeMessage.saveToFile() = SaveToFileMessage;
+
+  const factory QrCodeMessage.updateExportType(ExportType type) =
+      UpdateExportTypeMessage;
 }

--- a/lib/tools/qr_code/feature/message/qr_code_message.freezed.dart
+++ b/lib/tools/qr_code/feature/message/qr_code_message.freezed.dart
@@ -21,6 +21,7 @@ mixin _$QrCodeMessage {
     required TResult Function(String text) updateInput,
     required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
     required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -28,6 +29,7 @@ mixin _$QrCodeMessage {
     TResult? Function(String text)? updateInput,
     TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -35,6 +37,7 @@ mixin _$QrCodeMessage {
     TResult Function(String text)? updateInput,
     TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -44,6 +47,7 @@ mixin _$QrCodeMessage {
     required TResult Function(UpdateCorrectionLevelMessage value)
         updateCorrectionLevel,
     required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -52,6 +56,7 @@ mixin _$QrCodeMessage {
     TResult? Function(UpdateCorrectionLevelMessage value)?
         updateCorrectionLevel,
     TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -59,6 +64,7 @@ mixin _$QrCodeMessage {
     TResult Function(UpdateInputMessage value)? updateInput,
     TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
     TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -157,6 +163,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     required TResult Function(String text) updateInput,
     required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
     required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
   }) {
     return updateInput(text);
   }
@@ -167,6 +174,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult? Function(String text)? updateInput,
     TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
   }) {
     return updateInput?.call(text);
   }
@@ -177,6 +185,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult Function(String text)? updateInput,
     TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
     required TResult orElse(),
   }) {
     if (updateInput != null) {
@@ -192,6 +201,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     required TResult Function(UpdateCorrectionLevelMessage value)
         updateCorrectionLevel,
     required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
   }) {
     return updateInput(this);
   }
@@ -203,6 +213,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult? Function(UpdateCorrectionLevelMessage value)?
         updateCorrectionLevel,
     TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
   }) {
     return updateInput?.call(this);
   }
@@ -213,6 +224,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult Function(UpdateInputMessage value)? updateInput,
     TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
     TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
     required TResult orElse(),
   }) {
     if (updateInput != null) {
@@ -312,6 +324,7 @@ class _$UpdateCorrectionLevelMessageImpl
     required TResult Function(String text) updateInput,
     required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
     required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
   }) {
     return updateCorrectionLevel(level);
   }
@@ -322,6 +335,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult? Function(String text)? updateInput,
     TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
   }) {
     return updateCorrectionLevel?.call(level);
   }
@@ -332,6 +346,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult Function(String text)? updateInput,
     TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
     required TResult orElse(),
   }) {
     if (updateCorrectionLevel != null) {
@@ -347,6 +362,7 @@ class _$UpdateCorrectionLevelMessageImpl
     required TResult Function(UpdateCorrectionLevelMessage value)
         updateCorrectionLevel,
     required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
   }) {
     return updateCorrectionLevel(this);
   }
@@ -358,6 +374,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult? Function(UpdateCorrectionLevelMessage value)?
         updateCorrectionLevel,
     TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
   }) {
     return updateCorrectionLevel?.call(this);
   }
@@ -368,6 +385,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult Function(UpdateInputMessage value)? updateInput,
     TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
     TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
     required TResult orElse(),
   }) {
     if (updateCorrectionLevel != null) {
@@ -435,6 +453,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     required TResult Function(String text) updateInput,
     required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
     required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
   }) {
     return saveToFile();
   }
@@ -445,6 +464,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult? Function(String text)? updateInput,
     TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
   }) {
     return saveToFile?.call();
   }
@@ -455,6 +475,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult Function(String text)? updateInput,
     TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
     TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
@@ -470,6 +491,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     required TResult Function(UpdateCorrectionLevelMessage value)
         updateCorrectionLevel,
     required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
   }) {
     return saveToFile(this);
   }
@@ -481,6 +503,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult? Function(UpdateCorrectionLevelMessage value)?
         updateCorrectionLevel,
     TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
   }) {
     return saveToFile?.call(this);
   }
@@ -491,6 +514,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult Function(UpdateInputMessage value)? updateInput,
     TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
     TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
@@ -502,4 +526,162 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
 
 abstract class SaveToFileMessage implements QrCodeMessage {
   const factory SaveToFileMessage() = _$SaveToFileMessageImpl;
+}
+
+/// @nodoc
+abstract class _$$UpdateExportTypeMessageImplCopyWith<$Res> {
+  factory _$$UpdateExportTypeMessageImplCopyWith(
+          _$UpdateExportTypeMessageImpl value,
+          $Res Function(_$UpdateExportTypeMessageImpl) then) =
+      __$$UpdateExportTypeMessageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ExportType type});
+}
+
+/// @nodoc
+class __$$UpdateExportTypeMessageImplCopyWithImpl<$Res>
+    extends _$QrCodeMessageCopyWithImpl<$Res, _$UpdateExportTypeMessageImpl>
+    implements _$$UpdateExportTypeMessageImplCopyWith<$Res> {
+  __$$UpdateExportTypeMessageImplCopyWithImpl(
+      _$UpdateExportTypeMessageImpl _value,
+      $Res Function(_$UpdateExportTypeMessageImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+  }) {
+    return _then(_$UpdateExportTypeMessageImpl(
+      null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ExportType,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
+  const _$UpdateExportTypeMessageImpl(this.type);
+
+  @override
+  final ExportType type;
+
+  @override
+  String toString() {
+    return 'QrCodeMessage.updateExportType(type: $type)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UpdateExportTypeMessageImpl &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, type);
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UpdateExportTypeMessageImplCopyWith<_$UpdateExportTypeMessageImpl>
+      get copyWith => __$$UpdateExportTypeMessageImplCopyWithImpl<
+          _$UpdateExportTypeMessageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String text) updateInput,
+    required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
+    required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
+  }) {
+    return updateExportType(type);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String text)? updateInput,
+    TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
+    TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
+  }) {
+    return updateExportType?.call(type);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String text)? updateInput,
+    TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
+    TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
+    required TResult orElse(),
+  }) {
+    if (updateExportType != null) {
+      return updateExportType(type);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(UpdateInputMessage value) updateInput,
+    required TResult Function(UpdateCorrectionLevelMessage value)
+        updateCorrectionLevel,
+    required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
+  }) {
+    return updateExportType(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(UpdateInputMessage value)? updateInput,
+    TResult? Function(UpdateCorrectionLevelMessage value)?
+        updateCorrectionLevel,
+    TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
+  }) {
+    return updateExportType?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(UpdateInputMessage value)? updateInput,
+    TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
+    TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
+    required TResult orElse(),
+  }) {
+    if (updateExportType != null) {
+      return updateExportType(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UpdateExportTypeMessage implements QrCodeMessage {
+  const factory UpdateExportTypeMessage(final ExportType type) =
+      _$UpdateExportTypeMessageImpl;
+
+  ExportType get type;
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UpdateExportTypeMessageImplCopyWith<_$UpdateExportTypeMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/tools/qr_code/feature/qr_code_effect_handler.dart
+++ b/lib/tools/qr_code/feature/qr_code_effect_handler.dart
@@ -1,13 +1,15 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
-import 'package:image/image.dart';
+import 'package:image/image.dart' as img;
 import 'package:mini_tea/feature.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import 'effect/qr_code_effect.dart';
 import 'message/qr_code_message.dart';
+import 'state/qr_code_state.dart';
 
 final class QrCodeEffectHandler
     implements EffectHandler<QrCodeEffect, QrCodeMessage> {
@@ -28,34 +30,82 @@ final class QrCodeEffectHandler
   ) async {
     final path = await FilePicker.platform.saveFile(
       type: FileType.image,
-      fileName: 'qr_code.png',
+      fileName: 'qr_code.${effect.exportType.extension}',
     );
-
     if (path == null) {
       return;
     }
+    final file = File(path);
 
+    switch (effect.exportType) {
+      case ExportType.png:
+        final content = await generateQrCodeRaster(effect.code).then(encodePng);
+        if (content != null) {
+          await file.writeAsBytes(content);
+        }
+        break;
+      case ExportType.jpg:
+        final content = await generateQrCodeRaster(effect.code).then(encodeJpg);
+        if (content != null) {
+          await file.writeAsBytes(content);
+        }
+        break;
+      case ExportType.svg:
+        final content = generateQrCodeSvg(effect.code);
+        await file.writeAsString(content);
+        break;
+    }
+  }
+
+  /// Generate content for SVG version of this QR code
+  static String generateQrCodeSvg(QrCode qrCode) {
+    final qrImage = QrImage(qrCode);
+
+    final StringBuffer svgContent = StringBuffer(
+        '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" '
+        'width="600" height="600" viewBox="0 0 ${qrImage.moduleCount} ${qrImage.moduleCount}">');
+
+    for (int x = 0; x < qrImage.moduleCount; x++) {
+      for (int y = 0; y < qrImage.moduleCount; y++) {
+        if (qrImage.isDark(y, x)) {
+          svgContent.write('<rect x="$x" y="$y" width="1" height="1" />');
+        }
+      }
+    }
+
+    svgContent.write('</svg>');
+
+    return svgContent.toString();
+  }
+
+  /// Generate bytes content for vector graphic around this qr code
+  static Future<img.Image?> generateQrCodeRaster(QrCode qrCode) async {
     final painter = QrPainter.withQr(
-      qr: effect.code,
+      qr: qrCode,
       gapless: true,
     );
     final data = await painter.toImageData(600);
 
     if (data == null) {
-      return;
+      return null;
     }
 
-    final qrImage = decodePng(data.buffer.asUint8List());
+    final qrImage = img.decodePng(data.buffer.asUint8List());
 
     if (qrImage == null) {
-      return;
+      return null;
     }
 
-    Image image = Image(height: 600, width: 600);
-    image = fill(image, color: ColorInt8.rgb(127, 127, 127));
-    image = compositeImage(image, qrImage);
+    img.Image image = img.Image(height: 600, width: 600);
+    image = img.fill(image, color: img.ColorInt8.rgb(127, 127, 127));
+    image = img.compositeImage(image, qrImage);
 
-    final file = File(path);
-    await file.writeAsBytes(encodePng(image));
+    return image;
   }
+
+  static Uint8List? encodePng(img.Image? image) =>
+      image != null ? img.encodePng(image) : null;
+
+  static Uint8List? encodeJpg(img.Image? image) =>
+      image != null ? img.encodeJpg(image) : null;
 }

--- a/lib/tools/qr_code/feature/qr_code_update.dart
+++ b/lib/tools/qr_code/feature/qr_code_update.dart
@@ -30,9 +30,15 @@ Next<QrCodeState, QrCodeEffect> qrCodeUpdate(
       final code = state.code;
       return next(
         effects: [
-          if (code != null) QrCodeEffect.saveToFile(code: code),
+          if (code != null)
+            QrCodeEffect.saveToFile(
+              code: code,
+              exportType: state.exportType,
+            ),
         ],
       );
+    case UpdateExportTypeMessage():
+      return next(state: state.copyWith(exportType: message.type));
   }
 }
 

--- a/lib/tools/qr_code/feature/state/qr_code_state.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.dart
@@ -10,12 +10,26 @@ enum ErrorCorrectionLevel {
   H, // High 30%
 }
 
+enum ExportType {
+  png,
+  jpg,
+  svg,
+}
+
 extension ErrorCorrectionLevelUtils on ErrorCorrectionLevel {
   int get toInt => switch (this) {
         ErrorCorrectionLevel.L => QrErrorCorrectLevel.L,
         ErrorCorrectionLevel.M => QrErrorCorrectLevel.M,
         ErrorCorrectionLevel.Q => QrErrorCorrectLevel.Q,
         ErrorCorrectionLevel.H => QrErrorCorrectLevel.H,
+      };
+}
+
+extension ExportTypeUtils on ExportType {
+  String get extension => switch (this) {
+        ExportType.png => 'png',
+        ExportType.jpg => 'jpg',
+        ExportType.svg => 'svg',
       };
 }
 
@@ -26,11 +40,13 @@ class QrCodeState with _$QrCodeState {
     required QrCode? code,
     required String input,
     required ErrorCorrectionLevel correctionLevel,
+    required ExportType exportType,
   }) = _QrCodeState;
 
   factory QrCodeState.initialState() => const QrCodeState(
         code: null,
         input: '',
         correctionLevel: ErrorCorrectionLevel.H,
+        exportType: ExportType.png,
       );
 }

--- a/lib/tools/qr_code/feature/state/qr_code_state.freezed.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.freezed.dart
@@ -20,6 +20,7 @@ mixin _$QrCodeState {
   String get input => throw _privateConstructorUsedError;
   ErrorCorrectionLevel get correctionLevel =>
       throw _privateConstructorUsedError;
+  ExportType get exportType => throw _privateConstructorUsedError;
 
   /// Create a copy of QrCodeState
   /// with the given fields replaced by the non-null parameter values.
@@ -34,7 +35,11 @@ abstract class $QrCodeStateCopyWith<$Res> {
           QrCodeState value, $Res Function(QrCodeState) then) =
       _$QrCodeStateCopyWithImpl<$Res, QrCodeState>;
   @useResult
-  $Res call({QrCode? code, String input, ErrorCorrectionLevel correctionLevel});
+  $Res call(
+      {QrCode? code,
+      String input,
+      ErrorCorrectionLevel correctionLevel,
+      ExportType exportType});
 }
 
 /// @nodoc
@@ -55,6 +60,7 @@ class _$QrCodeStateCopyWithImpl<$Res, $Val extends QrCodeState>
     Object? code = freezed,
     Object? input = null,
     Object? correctionLevel = null,
+    Object? exportType = null,
   }) {
     return _then(_value.copyWith(
       code: freezed == code
@@ -69,6 +75,10 @@ class _$QrCodeStateCopyWithImpl<$Res, $Val extends QrCodeState>
           ? _value.correctionLevel
           : correctionLevel // ignore: cast_nullable_to_non_nullable
               as ErrorCorrectionLevel,
+      exportType: null == exportType
+          ? _value.exportType
+          : exportType // ignore: cast_nullable_to_non_nullable
+              as ExportType,
     ) as $Val);
   }
 }
@@ -81,7 +91,11 @@ abstract class _$$QrCodeStateImplCopyWith<$Res>
       __$$QrCodeStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({QrCode? code, String input, ErrorCorrectionLevel correctionLevel});
+  $Res call(
+      {QrCode? code,
+      String input,
+      ErrorCorrectionLevel correctionLevel,
+      ExportType exportType});
 }
 
 /// @nodoc
@@ -100,6 +114,7 @@ class __$$QrCodeStateImplCopyWithImpl<$Res>
     Object? code = freezed,
     Object? input = null,
     Object? correctionLevel = null,
+    Object? exportType = null,
   }) {
     return _then(_$QrCodeStateImpl(
       code: freezed == code
@@ -114,6 +129,10 @@ class __$$QrCodeStateImplCopyWithImpl<$Res>
           ? _value.correctionLevel
           : correctionLevel // ignore: cast_nullable_to_non_nullable
               as ErrorCorrectionLevel,
+      exportType: null == exportType
+          ? _value.exportType
+          : exportType // ignore: cast_nullable_to_non_nullable
+              as ExportType,
     ));
   }
 }
@@ -122,7 +141,10 @@ class __$$QrCodeStateImplCopyWithImpl<$Res>
 
 class _$QrCodeStateImpl implements _QrCodeState {
   const _$QrCodeStateImpl(
-      {required this.code, required this.input, required this.correctionLevel});
+      {required this.code,
+      required this.input,
+      required this.correctionLevel,
+      required this.exportType});
 
   @override
   final QrCode? code;
@@ -130,10 +152,12 @@ class _$QrCodeStateImpl implements _QrCodeState {
   final String input;
   @override
   final ErrorCorrectionLevel correctionLevel;
+  @override
+  final ExportType exportType;
 
   @override
   String toString() {
-    return 'QrCodeState(code: $code, input: $input, correctionLevel: $correctionLevel)';
+    return 'QrCodeState(code: $code, input: $input, correctionLevel: $correctionLevel, exportType: $exportType)';
   }
 
   @override
@@ -144,11 +168,14 @@ class _$QrCodeStateImpl implements _QrCodeState {
             (identical(other.code, code) || other.code == code) &&
             (identical(other.input, input) || other.input == input) &&
             (identical(other.correctionLevel, correctionLevel) ||
-                other.correctionLevel == correctionLevel));
+                other.correctionLevel == correctionLevel) &&
+            (identical(other.exportType, exportType) ||
+                other.exportType == exportType));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, code, input, correctionLevel);
+  int get hashCode =>
+      Object.hash(runtimeType, code, input, correctionLevel, exportType);
 
   /// Create a copy of QrCodeState
   /// with the given fields replaced by the non-null parameter values.
@@ -163,7 +190,8 @@ abstract class _QrCodeState implements QrCodeState {
   const factory _QrCodeState(
       {required final QrCode? code,
       required final String input,
-      required final ErrorCorrectionLevel correctionLevel}) = _$QrCodeStateImpl;
+      required final ErrorCorrectionLevel correctionLevel,
+      required final ExportType exportType}) = _$QrCodeStateImpl;
 
   @override
   QrCode? get code;
@@ -171,6 +199,8 @@ abstract class _QrCodeState implements QrCodeState {
   String get input;
   @override
   ErrorCorrectionLevel get correctionLevel;
+  @override
+  ExportType get exportType;
 
   /// Create a copy of QrCodeState
   /// with the given fields replaced by the non-null parameter values.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - QR code exports now support multiple formats—PNG, JPG, and SVG.
  - A new export type selector has been added to the interface, allowing users to choose their desired format.
  - The app displays localized text for these export formats, enhancing the overall user experience when generating and saving QR codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->