### PR TITLE
#193: Base for `HintButton`

### DIFF
--- a/lib/common/ui/hint_button.dart
+++ b/lib/common/ui/hint_button.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_popup/flutter_popup.dart';
+import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/utils/utils.dart';
+
+class HintButton extends StatelessWidget {
+  final Widget hint;
+
+  HintButton({
+    required String hint,
+    super.key,
+  }) : hint = Text(hint);
+
+  const HintButton.rich({
+    required this.hint,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = MacosTheme.of(context);
+
+    return CustomPopup(
+      arrowColor: theme.popupButtonTheme.popupColor,
+      backgroundColor: theme.popupButtonTheme.popupColor,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: 300,
+        ),
+        child: hint,
+      ),
+      child: CircleAvatar(
+        backgroundColor: theme.helpButtonTheme.color,
+        foregroundColor: helpIconLuminance(
+          theme.helpButtonTheme.color!,
+          theme.brightness == Brightness.dark,
+        ),
+        radius: 10,
+        child: const Icon(
+          CupertinoIcons.question,
+          size: 13,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/ui/hint_button.dart
+++ b/lib/common/ui/hint_button.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_popup/flutter_popup.dart';
 import 'package:macos_ui/macos_ui.dart';
+
+// ignore:implementation_imports
 import 'package:macos_ui/src/utils/utils.dart';
 
 class HintButton extends StatelessWidget {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable hint button that displays contextual help.
	- Supports both simple text hints and richer content, with styling integrated to match the macOS design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->