### PR TITLE
#237: Set export size for the QR code

### DIFF
--- a/assets/i18n/strings.i18n.json
+++ b/assets/i18n/strings.i18n.json
@@ -326,6 +326,8 @@
       "svg_warning": "Shape style remain unchanged in SVG format"
     },
     "foreground_color_title": "Foreground color:",
-    "background_color_title": "Background color:"
+    "background_color_title": "Background color:",
+    "export_size_title": "Export size:",
+    "export_size_px": "px"
   }
 }

--- a/assets/i18n/strings.i18n.json
+++ b/assets/i18n/strings.i18n.json
@@ -328,6 +328,7 @@
     "foreground_color_title": "Foreground color:",
     "background_color_title": "Background color:",
     "export_size_title": "Export size:",
-    "export_size_px": "px"
+    "export_size_px": "px",
+    "export_size_hint": "From $from to $to pixels"
   }
 }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 235
+/// Strings: 236
 ///
-/// Built on 2025-05-11 at 22:27 UTC
+/// Built on 2025-05-11 at 22:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -469,6 +469,8 @@ class _StringsQrCodeEn {
   String get backgroundColorTitle => 'Background color:';
   String get exportSizeTitle => 'Export size:';
   String get exportSizePx => 'px';
+  String exportSizeHint({required Object from, required Object to}) =>
+      'From ${from} to ${to} pixels';
 }
 
 // Path: common.dayOfWeek
@@ -1386,6 +1388,9 @@ extension on Translations {
         return 'Export size:';
       case 'qrCode.exportSizePx':
         return 'px';
+      case 'qrCode.exportSizeHint':
+        return ({required Object from, required Object to}) =>
+            'From ${from} to ${to} pixels';
       default:
         return null;
     }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 233
+/// Strings: 235
 ///
-/// Built on 2025-05-10 at 23:11 UTC
+/// Built on 2025-05-11 at 22:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -467,6 +467,8 @@ class _StringsQrCodeEn {
   late final _StringsQrCodeShapesEn shapes = _StringsQrCodeShapesEn._(_root);
   String get foregroundColorTitle => 'Foreground color:';
   String get backgroundColorTitle => 'Background color:';
+  String get exportSizeTitle => 'Export size:';
+  String get exportSizePx => 'px';
 }
 
 // Path: common.dayOfWeek
@@ -1380,6 +1382,10 @@ extension on Translations {
         return 'Foreground color:';
       case 'qrCode.backgroundColorTitle':
         return 'Background color:';
+      case 'qrCode.exportSizeTitle':
+        return 'Export size:';
+      case 'qrCode.exportSizePx':
+        return 'px';
       default:
         return null;
     }

--- a/lib/tools/qr_code/feature/effect/qr_code_effect.dart
+++ b/lib/tools/qr_code/feature/effect/qr_code_effect.dart
@@ -11,11 +11,13 @@ sealed class QrCodeEffect {
     required QrCode code,
     required ExportType exportType,
     required QrCodeVisualData visualData,
+    required int exportSize,
   }) = SaveToFileEffect;
 
   const factory QrCodeEffect.copyToClipboard({
     required QrCode code,
     required QrCodeVisualData visualData,
+    required int exportSize,
   }) = CopyToClipboardEffect;
 
   const factory QrCodeEffect.saveState({
@@ -32,11 +34,13 @@ sealed class ExportEffect with _$ExportEffect implements QrCodeEffect {
     required QrCode code,
     required ExportType exportType,
     required QrCodeVisualData visualData,
+    required int exportSize,
   }) = SaveToFileEffect;
 
   const factory ExportEffect.copyToClipboard({
     required QrCode code,
     required QrCodeVisualData visualData,
+    required int exportSize,
   }) = CopyToClipboardEffect;
 }
 

--- a/lib/tools/qr_code/feature/effect/qr_code_effect.freezed.dart
+++ b/lib/tools/qr_code/feature/effect/qr_code_effect.freezed.dart
@@ -18,30 +18,33 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$ExportEffect {
   QrCode get code => throw _privateConstructorUsedError;
   QrCodeVisualData get visualData => throw _privateConstructorUsedError;
+  int get exportSize => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)
+    required TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)
         saveToFile,
-    required TResult Function(QrCode code, QrCodeVisualData visualData)
+    required TResult Function(
+            QrCode code, QrCodeVisualData visualData, int exportSize)
         copyToClipboard,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult? Function(QrCode code, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
         copyToClipboard,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult Function(QrCode code, QrCodeVisualData visualData)? copyToClipboard,
+    TResult Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
+        copyToClipboard,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -78,7 +81,7 @@ abstract class $ExportEffectCopyWith<$Res> {
           ExportEffect value, $Res Function(ExportEffect) then) =
       _$ExportEffectCopyWithImpl<$Res, ExportEffect>;
   @useResult
-  $Res call({QrCode code, QrCodeVisualData visualData});
+  $Res call({QrCode code, QrCodeVisualData visualData, int exportSize});
 
   $QrCodeVisualDataCopyWith<$Res> get visualData;
 }
@@ -100,6 +103,7 @@ class _$ExportEffectCopyWithImpl<$Res, $Val extends ExportEffect>
   $Res call({
     Object? code = null,
     Object? visualData = null,
+    Object? exportSize = null,
   }) {
     return _then(_value.copyWith(
       code: null == code
@@ -110,6 +114,10 @@ class _$ExportEffectCopyWithImpl<$Res, $Val extends ExportEffect>
           ? _value.visualData
           : visualData // ignore: cast_nullable_to_non_nullable
               as QrCodeVisualData,
+      exportSize: null == exportSize
+          ? _value.exportSize
+          : exportSize // ignore: cast_nullable_to_non_nullable
+              as int,
     ) as $Val);
   }
 
@@ -132,7 +140,11 @@ abstract class _$$SaveToFileEffectImplCopyWith<$Res>
       __$$SaveToFileEffectImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({QrCode code, ExportType exportType, QrCodeVisualData visualData});
+  $Res call(
+      {QrCode code,
+      ExportType exportType,
+      QrCodeVisualData visualData,
+      int exportSize});
 
   @override
   $QrCodeVisualDataCopyWith<$Res> get visualData;
@@ -154,6 +166,7 @@ class __$$SaveToFileEffectImplCopyWithImpl<$Res>
     Object? code = null,
     Object? exportType = null,
     Object? visualData = null,
+    Object? exportSize = null,
   }) {
     return _then(_$SaveToFileEffectImpl(
       code: null == code
@@ -168,6 +181,10 @@ class __$$SaveToFileEffectImplCopyWithImpl<$Res>
           ? _value.visualData
           : visualData // ignore: cast_nullable_to_non_nullable
               as QrCodeVisualData,
+      exportSize: null == exportSize
+          ? _value.exportSize
+          : exportSize // ignore: cast_nullable_to_non_nullable
+              as int,
     ));
   }
 }
@@ -176,7 +193,10 @@ class __$$SaveToFileEffectImplCopyWithImpl<$Res>
 
 class _$SaveToFileEffectImpl implements SaveToFileEffect {
   const _$SaveToFileEffectImpl(
-      {required this.code, required this.exportType, required this.visualData});
+      {required this.code,
+      required this.exportType,
+      required this.visualData,
+      required this.exportSize});
 
   @override
   final QrCode code;
@@ -184,10 +204,12 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
   final ExportType exportType;
   @override
   final QrCodeVisualData visualData;
+  @override
+  final int exportSize;
 
   @override
   String toString() {
-    return 'ExportEffect.saveToFile(code: $code, exportType: $exportType, visualData: $visualData)';
+    return 'ExportEffect.saveToFile(code: $code, exportType: $exportType, visualData: $visualData, exportSize: $exportSize)';
   }
 
   @override
@@ -199,11 +221,14 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
             (identical(other.exportType, exportType) ||
                 other.exportType == exportType) &&
             (identical(other.visualData, visualData) ||
-                other.visualData == visualData));
+                other.visualData == visualData) &&
+            (identical(other.exportSize, exportSize) ||
+                other.exportSize == exportSize));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, code, exportType, visualData);
+  int get hashCode =>
+      Object.hash(runtimeType, code, exportType, visualData, exportSize);
 
   /// Create a copy of ExportEffect
   /// with the given fields replaced by the non-null parameter values.
@@ -217,38 +242,40 @@ class _$SaveToFileEffectImpl implements SaveToFileEffect {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)
+    required TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)
         saveToFile,
-    required TResult Function(QrCode code, QrCodeVisualData visualData)
+    required TResult Function(
+            QrCode code, QrCodeVisualData visualData, int exportSize)
         copyToClipboard,
   }) {
-    return saveToFile(code, exportType, visualData);
+    return saveToFile(code, exportType, visualData, exportSize);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult? Function(QrCode code, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
         copyToClipboard,
   }) {
-    return saveToFile?.call(code, exportType, visualData);
+    return saveToFile?.call(code, exportType, visualData, exportSize);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult Function(QrCode code, QrCodeVisualData visualData)? copyToClipboard,
+    TResult Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
+        copyToClipboard,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
-      return saveToFile(code, exportType, visualData);
+      return saveToFile(code, exportType, visualData, exportSize);
     }
     return orElse();
   }
@@ -289,13 +316,16 @@ abstract class SaveToFileEffect implements ExportEffect {
   const factory SaveToFileEffect(
       {required final QrCode code,
       required final ExportType exportType,
-      required final QrCodeVisualData visualData}) = _$SaveToFileEffectImpl;
+      required final QrCodeVisualData visualData,
+      required final int exportSize}) = _$SaveToFileEffectImpl;
 
   @override
   QrCode get code;
   ExportType get exportType;
   @override
   QrCodeVisualData get visualData;
+  @override
+  int get exportSize;
 
   /// Create a copy of ExportEffect
   /// with the given fields replaced by the non-null parameter values.
@@ -314,7 +344,7 @@ abstract class _$$CopyToClipboardEffectImplCopyWith<$Res>
       __$$CopyToClipboardEffectImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({QrCode code, QrCodeVisualData visualData});
+  $Res call({QrCode code, QrCodeVisualData visualData, int exportSize});
 
   @override
   $QrCodeVisualDataCopyWith<$Res> get visualData;
@@ -335,6 +365,7 @@ class __$$CopyToClipboardEffectImplCopyWithImpl<$Res>
   $Res call({
     Object? code = null,
     Object? visualData = null,
+    Object? exportSize = null,
   }) {
     return _then(_$CopyToClipboardEffectImpl(
       code: null == code
@@ -345,6 +376,10 @@ class __$$CopyToClipboardEffectImplCopyWithImpl<$Res>
           ? _value.visualData
           : visualData // ignore: cast_nullable_to_non_nullable
               as QrCodeVisualData,
+      exportSize: null == exportSize
+          ? _value.exportSize
+          : exportSize // ignore: cast_nullable_to_non_nullable
+              as int,
     ));
   }
 }
@@ -353,16 +388,18 @@ class __$$CopyToClipboardEffectImplCopyWithImpl<$Res>
 
 class _$CopyToClipboardEffectImpl implements CopyToClipboardEffect {
   const _$CopyToClipboardEffectImpl(
-      {required this.code, required this.visualData});
+      {required this.code, required this.visualData, required this.exportSize});
 
   @override
   final QrCode code;
   @override
   final QrCodeVisualData visualData;
+  @override
+  final int exportSize;
 
   @override
   String toString() {
-    return 'ExportEffect.copyToClipboard(code: $code, visualData: $visualData)';
+    return 'ExportEffect.copyToClipboard(code: $code, visualData: $visualData, exportSize: $exportSize)';
   }
 
   @override
@@ -372,11 +409,13 @@ class _$CopyToClipboardEffectImpl implements CopyToClipboardEffect {
             other is _$CopyToClipboardEffectImpl &&
             (identical(other.code, code) || other.code == code) &&
             (identical(other.visualData, visualData) ||
-                other.visualData == visualData));
+                other.visualData == visualData) &&
+            (identical(other.exportSize, exportSize) ||
+                other.exportSize == exportSize));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, code, visualData);
+  int get hashCode => Object.hash(runtimeType, code, visualData, exportSize);
 
   /// Create a copy of ExportEffect
   /// with the given fields replaced by the non-null parameter values.
@@ -390,38 +429,40 @@ class _$CopyToClipboardEffectImpl implements CopyToClipboardEffect {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)
+    required TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)
         saveToFile,
-    required TResult Function(QrCode code, QrCodeVisualData visualData)
+    required TResult Function(
+            QrCode code, QrCodeVisualData visualData, int exportSize)
         copyToClipboard,
   }) {
-    return copyToClipboard(code, visualData);
+    return copyToClipboard(code, visualData, exportSize);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult? Function(QrCode code, QrCodeVisualData visualData)?
+    TResult? Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
         copyToClipboard,
   }) {
-    return copyToClipboard?.call(code, visualData);
+    return copyToClipboard?.call(code, visualData, exportSize);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            QrCode code, ExportType exportType, QrCodeVisualData visualData)?
+    TResult Function(QrCode code, ExportType exportType,
+            QrCodeVisualData visualData, int exportSize)?
         saveToFile,
-    TResult Function(QrCode code, QrCodeVisualData visualData)? copyToClipboard,
+    TResult Function(QrCode code, QrCodeVisualData visualData, int exportSize)?
+        copyToClipboard,
     required TResult orElse(),
   }) {
     if (copyToClipboard != null) {
-      return copyToClipboard(code, visualData);
+      return copyToClipboard(code, visualData, exportSize);
     }
     return orElse();
   }
@@ -460,14 +501,16 @@ class _$CopyToClipboardEffectImpl implements CopyToClipboardEffect {
 
 abstract class CopyToClipboardEffect implements ExportEffect {
   const factory CopyToClipboardEffect(
-          {required final QrCode code,
-          required final QrCodeVisualData visualData}) =
-      _$CopyToClipboardEffectImpl;
+      {required final QrCode code,
+      required final QrCodeVisualData visualData,
+      required final int exportSize}) = _$CopyToClipboardEffectImpl;
 
   @override
   QrCode get code;
   @override
   QrCodeVisualData get visualData;
+  @override
+  int get exportSize;
 
   /// Create a copy of ExportEffect
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/tools/qr_code/feature/message/qr_code_message.dart
+++ b/lib/tools/qr_code/feature/message/qr_code_message.dart
@@ -34,4 +34,7 @@ sealed class QrCodeMessage with _$QrCodeMessage {
 
   const factory QrCodeMessage.backgroundColorUpdate(Color color) =
       BackgroundColorUpdateMessage;
+
+  const factory QrCodeMessage.exportSizeUpdate(int size) =
+      ExportSizeUpdateMessage;
 }

--- a/lib/tools/qr_code/feature/message/qr_code_message.freezed.dart
+++ b/lib/tools/qr_code/feature/message/qr_code_message.freezed.dart
@@ -28,6 +28,7 @@ mixin _$QrCodeMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -42,6 +43,7 @@ mixin _$QrCodeMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -56,6 +58,7 @@ mixin _$QrCodeMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -74,6 +77,7 @@ mixin _$QrCodeMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -91,6 +95,7 @@ mixin _$QrCodeMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -105,6 +110,7 @@ mixin _$QrCodeMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -222,6 +228,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return loadedState(state);
   }
@@ -239,6 +246,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return loadedState?.call(state);
   }
@@ -256,6 +264,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (loadedState != null) {
@@ -280,6 +289,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return loadedState(this);
   }
@@ -300,6 +310,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return loadedState?.call(this);
   }
@@ -317,6 +328,7 @@ class _$LoadedStateMessageImpl implements LoadedStateMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (loadedState != null) {
@@ -418,6 +430,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return updateInput(text);
   }
@@ -435,6 +448,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return updateInput?.call(text);
   }
@@ -452,6 +466,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateInput != null) {
@@ -476,6 +491,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return updateInput(this);
   }
@@ -496,6 +512,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return updateInput?.call(this);
   }
@@ -513,6 +530,7 @@ class _$UpdateInputMessageImpl implements UpdateInputMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateInput != null) {
@@ -619,6 +637,7 @@ class _$UpdateCorrectionLevelMessageImpl
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return updateCorrectionLevel(level);
   }
@@ -636,6 +655,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return updateCorrectionLevel?.call(level);
   }
@@ -653,6 +673,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateCorrectionLevel != null) {
@@ -677,6 +698,7 @@ class _$UpdateCorrectionLevelMessageImpl
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return updateCorrectionLevel(this);
   }
@@ -697,6 +719,7 @@ class _$UpdateCorrectionLevelMessageImpl
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return updateCorrectionLevel?.call(this);
   }
@@ -714,6 +737,7 @@ class _$UpdateCorrectionLevelMessageImpl
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateCorrectionLevel != null) {
@@ -788,6 +812,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return saveToFile();
   }
@@ -805,6 +830,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return saveToFile?.call();
   }
@@ -822,6 +848,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
@@ -846,6 +873,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return saveToFile(this);
   }
@@ -866,6 +894,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return saveToFile?.call(this);
   }
@@ -883,6 +912,7 @@ class _$SaveToFileMessageImpl implements SaveToFileMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (saveToFile != null) {
@@ -977,6 +1007,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return updateExportType(type);
   }
@@ -994,6 +1025,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return updateExportType?.call(type);
   }
@@ -1011,6 +1043,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateExportType != null) {
@@ -1035,6 +1068,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return updateExportType(this);
   }
@@ -1055,6 +1089,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return updateExportType?.call(this);
   }
@@ -1072,6 +1107,7 @@ class _$UpdateExportTypeMessageImpl implements UpdateExportTypeMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (updateExportType != null) {
@@ -1148,6 +1184,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return copyToClipboard();
   }
@@ -1165,6 +1202,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return copyToClipboard?.call();
   }
@@ -1182,6 +1220,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (copyToClipboard != null) {
@@ -1206,6 +1245,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return copyToClipboard(this);
   }
@@ -1226,6 +1266,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return copyToClipboard?.call(this);
   }
@@ -1243,6 +1284,7 @@ class _$CopyToClipboardMessageImpl implements CopyToClipboardMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (copyToClipboard != null) {
@@ -1335,6 +1377,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return shapeUpdate(shape);
   }
@@ -1352,6 +1395,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return shapeUpdate?.call(shape);
   }
@@ -1369,6 +1413,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (shapeUpdate != null) {
@@ -1393,6 +1438,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return shapeUpdate(this);
   }
@@ -1413,6 +1459,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return shapeUpdate?.call(this);
   }
@@ -1430,6 +1477,7 @@ class _$ShapeUpdateMessageImpl implements ShapeUpdateMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (shapeUpdate != null) {
@@ -1532,6 +1580,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return paddingUpdate(padding);
   }
@@ -1549,6 +1598,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return paddingUpdate?.call(padding);
   }
@@ -1566,6 +1616,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (paddingUpdate != null) {
@@ -1590,6 +1641,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return paddingUpdate(this);
   }
@@ -1610,6 +1662,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return paddingUpdate?.call(this);
   }
@@ -1627,6 +1680,7 @@ class _$PaddingUpdateMessageImpl implements PaddingUpdateMessage {
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (paddingUpdate != null) {
@@ -1733,6 +1787,7 @@ class _$ForegroundColorUpdateMessageImpl
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return foregroundColorUpdate(color);
   }
@@ -1750,6 +1805,7 @@ class _$ForegroundColorUpdateMessageImpl
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return foregroundColorUpdate?.call(color);
   }
@@ -1767,6 +1823,7 @@ class _$ForegroundColorUpdateMessageImpl
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (foregroundColorUpdate != null) {
@@ -1791,6 +1848,7 @@ class _$ForegroundColorUpdateMessageImpl
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return foregroundColorUpdate(this);
   }
@@ -1811,6 +1869,7 @@ class _$ForegroundColorUpdateMessageImpl
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return foregroundColorUpdate?.call(this);
   }
@@ -1828,6 +1887,7 @@ class _$ForegroundColorUpdateMessageImpl
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (foregroundColorUpdate != null) {
@@ -1935,6 +1995,7 @@ class _$BackgroundColorUpdateMessageImpl
     required TResult Function(EdgeInsets padding) paddingUpdate,
     required TResult Function(Color color) foregroundColorUpdate,
     required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
   }) {
     return backgroundColorUpdate(color);
   }
@@ -1952,6 +2013,7 @@ class _$BackgroundColorUpdateMessageImpl
     TResult? Function(EdgeInsets padding)? paddingUpdate,
     TResult? Function(Color color)? foregroundColorUpdate,
     TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
   }) {
     return backgroundColorUpdate?.call(color);
   }
@@ -1969,6 +2031,7 @@ class _$BackgroundColorUpdateMessageImpl
     TResult Function(EdgeInsets padding)? paddingUpdate,
     TResult Function(Color color)? foregroundColorUpdate,
     TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (backgroundColorUpdate != null) {
@@ -1993,6 +2056,7 @@ class _$BackgroundColorUpdateMessageImpl
         foregroundColorUpdate,
     required TResult Function(BackgroundColorUpdateMessage value)
         backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
   }) {
     return backgroundColorUpdate(this);
   }
@@ -2013,6 +2077,7 @@ class _$BackgroundColorUpdateMessageImpl
         foregroundColorUpdate,
     TResult? Function(BackgroundColorUpdateMessage value)?
         backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
   }) {
     return backgroundColorUpdate?.call(this);
   }
@@ -2030,6 +2095,7 @@ class _$BackgroundColorUpdateMessageImpl
     TResult Function(PaddingUpdateMessage value)? paddingUpdate,
     TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
     TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
     required TResult orElse(),
   }) {
     if (backgroundColorUpdate != null) {
@@ -2050,5 +2116,209 @@ abstract class BackgroundColorUpdateMessage implements QrCodeMessage {
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$BackgroundColorUpdateMessageImplCopyWith<
           _$BackgroundColorUpdateMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ExportSizeUpdateMessageImplCopyWith<$Res> {
+  factory _$$ExportSizeUpdateMessageImplCopyWith(
+          _$ExportSizeUpdateMessageImpl value,
+          $Res Function(_$ExportSizeUpdateMessageImpl) then) =
+      __$$ExportSizeUpdateMessageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int size});
+}
+
+/// @nodoc
+class __$$ExportSizeUpdateMessageImplCopyWithImpl<$Res>
+    extends _$QrCodeMessageCopyWithImpl<$Res, _$ExportSizeUpdateMessageImpl>
+    implements _$$ExportSizeUpdateMessageImplCopyWith<$Res> {
+  __$$ExportSizeUpdateMessageImplCopyWithImpl(
+      _$ExportSizeUpdateMessageImpl _value,
+      $Res Function(_$ExportSizeUpdateMessageImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? size = null,
+  }) {
+    return _then(_$ExportSizeUpdateMessageImpl(
+      null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ExportSizeUpdateMessageImpl implements ExportSizeUpdateMessage {
+  const _$ExportSizeUpdateMessageImpl(this.size);
+
+  @override
+  final int size;
+
+  @override
+  String toString() {
+    return 'QrCodeMessage.exportSizeUpdate(size: $size)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ExportSizeUpdateMessageImpl &&
+            (identical(other.size, size) || other.size == size));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, size);
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ExportSizeUpdateMessageImplCopyWith<_$ExportSizeUpdateMessageImpl>
+      get copyWith => __$$ExportSizeUpdateMessageImplCopyWithImpl<
+          _$ExportSizeUpdateMessageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(QrCodeState state) loadedState,
+    required TResult Function(String text) updateInput,
+    required TResult Function(ErrorCorrectionLevel level) updateCorrectionLevel,
+    required TResult Function() saveToFile,
+    required TResult Function(ExportType type) updateExportType,
+    required TResult Function() copyToClipboard,
+    required TResult Function(QrCodeShape shape) shapeUpdate,
+    required TResult Function(EdgeInsets padding) paddingUpdate,
+    required TResult Function(Color color) foregroundColorUpdate,
+    required TResult Function(Color color) backgroundColorUpdate,
+    required TResult Function(int size) exportSizeUpdate,
+  }) {
+    return exportSizeUpdate(size);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(QrCodeState state)? loadedState,
+    TResult? Function(String text)? updateInput,
+    TResult? Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
+    TResult? Function()? saveToFile,
+    TResult? Function(ExportType type)? updateExportType,
+    TResult? Function()? copyToClipboard,
+    TResult? Function(QrCodeShape shape)? shapeUpdate,
+    TResult? Function(EdgeInsets padding)? paddingUpdate,
+    TResult? Function(Color color)? foregroundColorUpdate,
+    TResult? Function(Color color)? backgroundColorUpdate,
+    TResult? Function(int size)? exportSizeUpdate,
+  }) {
+    return exportSizeUpdate?.call(size);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(QrCodeState state)? loadedState,
+    TResult Function(String text)? updateInput,
+    TResult Function(ErrorCorrectionLevel level)? updateCorrectionLevel,
+    TResult Function()? saveToFile,
+    TResult Function(ExportType type)? updateExportType,
+    TResult Function()? copyToClipboard,
+    TResult Function(QrCodeShape shape)? shapeUpdate,
+    TResult Function(EdgeInsets padding)? paddingUpdate,
+    TResult Function(Color color)? foregroundColorUpdate,
+    TResult Function(Color color)? backgroundColorUpdate,
+    TResult Function(int size)? exportSizeUpdate,
+    required TResult orElse(),
+  }) {
+    if (exportSizeUpdate != null) {
+      return exportSizeUpdate(size);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(LoadedStateMessage value) loadedState,
+    required TResult Function(UpdateInputMessage value) updateInput,
+    required TResult Function(UpdateCorrectionLevelMessage value)
+        updateCorrectionLevel,
+    required TResult Function(SaveToFileMessage value) saveToFile,
+    required TResult Function(UpdateExportTypeMessage value) updateExportType,
+    required TResult Function(CopyToClipboardMessage value) copyToClipboard,
+    required TResult Function(ShapeUpdateMessage value) shapeUpdate,
+    required TResult Function(PaddingUpdateMessage value) paddingUpdate,
+    required TResult Function(ForegroundColorUpdateMessage value)
+        foregroundColorUpdate,
+    required TResult Function(BackgroundColorUpdateMessage value)
+        backgroundColorUpdate,
+    required TResult Function(ExportSizeUpdateMessage value) exportSizeUpdate,
+  }) {
+    return exportSizeUpdate(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(LoadedStateMessage value)? loadedState,
+    TResult? Function(UpdateInputMessage value)? updateInput,
+    TResult? Function(UpdateCorrectionLevelMessage value)?
+        updateCorrectionLevel,
+    TResult? Function(SaveToFileMessage value)? saveToFile,
+    TResult? Function(UpdateExportTypeMessage value)? updateExportType,
+    TResult? Function(CopyToClipboardMessage value)? copyToClipboard,
+    TResult? Function(ShapeUpdateMessage value)? shapeUpdate,
+    TResult? Function(PaddingUpdateMessage value)? paddingUpdate,
+    TResult? Function(ForegroundColorUpdateMessage value)?
+        foregroundColorUpdate,
+    TResult? Function(BackgroundColorUpdateMessage value)?
+        backgroundColorUpdate,
+    TResult? Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
+  }) {
+    return exportSizeUpdate?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(LoadedStateMessage value)? loadedState,
+    TResult Function(UpdateInputMessage value)? updateInput,
+    TResult Function(UpdateCorrectionLevelMessage value)? updateCorrectionLevel,
+    TResult Function(SaveToFileMessage value)? saveToFile,
+    TResult Function(UpdateExportTypeMessage value)? updateExportType,
+    TResult Function(CopyToClipboardMessage value)? copyToClipboard,
+    TResult Function(ShapeUpdateMessage value)? shapeUpdate,
+    TResult Function(PaddingUpdateMessage value)? paddingUpdate,
+    TResult Function(ForegroundColorUpdateMessage value)? foregroundColorUpdate,
+    TResult Function(BackgroundColorUpdateMessage value)? backgroundColorUpdate,
+    TResult Function(ExportSizeUpdateMessage value)? exportSizeUpdate,
+    required TResult orElse(),
+  }) {
+    if (exportSizeUpdate != null) {
+      return exportSizeUpdate(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ExportSizeUpdateMessage implements QrCodeMessage {
+  const factory ExportSizeUpdateMessage(final int size) =
+      _$ExportSizeUpdateMessageImpl;
+
+  int get size;
+
+  /// Create a copy of QrCodeMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ExportSizeUpdateMessageImplCopyWith<_$ExportSizeUpdateMessageImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/tools/qr_code/feature/qr_code_effect_handler.dart
+++ b/lib/tools/qr_code/feature/qr_code_effect_handler.dart
@@ -67,6 +67,7 @@ final class QrCodeEffectHandler
         final content = await exporter(
           qrCode: effect.code,
           visualData: effect.visualData,
+          exportSize: effect.exportSize,
         ).then(encodePng);
         if (content != null) {
           await file.writeAsBytes(content);
@@ -76,13 +77,18 @@ final class QrCodeEffectHandler
         final content = await exporter(
           qrCode: effect.code,
           visualData: effect.visualData,
+          exportSize: effect.exportSize,
         ).then(encodeJpg);
         if (content != null) {
           await file.writeAsBytes(content);
         }
         break;
       case ExportType.svg:
-        final content = generateQrCodeSvg(effect.code, effect.visualData);
+        final content = generateQrCodeSvg(
+          effect.code,
+          effect.visualData,
+          effect.exportSize,
+        );
         await file.writeAsString(content);
         break;
     }
@@ -92,6 +98,7 @@ final class QrCodeEffectHandler
   static String generateQrCodeSvg(
     QrCode qrCode,
     QrCodeVisualData visualData,
+    int exportSize,
   ) {
     final qrImage = QrImage(qrCode);
 
@@ -100,7 +107,7 @@ final class QrCodeEffectHandler
 
     final StringBuffer svgContent = StringBuffer(
         '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" '
-        'width="600" height="600" viewBox="0 0 ${qrImage.moduleCount} ${qrImage.moduleCount}">');
+        'width="$exportSize" height="$exportSize" viewBox="0 0 ${qrImage.moduleCount} ${qrImage.moduleCount}">');
 
     if (backgroundColor.opacity != 0) {
       // TODO(Vorkytaka): Add alpha channel
@@ -143,6 +150,7 @@ final class QrCodeEffectHandler
     final image = await exporter(
       qrCode: effect.code,
       visualData: effect.visualData,
+      exportSize: effect.exportSize,
     );
     final data = encodePng(image);
     if (data == null) {

--- a/lib/tools/qr_code/feature/qr_code_update.dart
+++ b/lib/tools/qr_code/feature/qr_code_update.dart
@@ -30,6 +30,7 @@ Next<QrCodeState, QrCodeEffect> qrCodeUpdate(
               code: code,
               exportType: state.exportType,
               visualData: state.visualData,
+              exportSize: state.exportSize,
             ),
         ],
       );
@@ -47,6 +48,7 @@ Next<QrCodeState, QrCodeEffect> qrCodeUpdate(
             QrCodeEffect.copyToClipboard(
               code: code,
               visualData: state.visualData,
+              exportSize: state.exportSize,
             ),
         ],
       );
@@ -88,6 +90,16 @@ Next<QrCodeState, QrCodeEffect> qrCodeUpdate(
           backgroundColor: message.color,
         ),
       );
+      return next(
+        state: newState,
+        effects: [QrCodeEffect.saveState(state: newState)],
+      );
+    case ExportSizeUpdateMessage():
+      final exportSize = message.size.clamp(
+        QrCodeState.minExportSize,
+        QrCodeState.maxExportSize,
+      );
+      final newState = state.copyWith(exportSize: exportSize);
       return next(
         state: newState,
         effects: [QrCodeEffect.saveState(state: newState)],

--- a/lib/tools/qr_code/feature/qr_exporter/qr_exporter.dart
+++ b/lib/tools/qr_code/feature/qr_exporter/qr_exporter.dart
@@ -6,4 +6,5 @@ import '../state/qr_code_state.dart';
 typedef QrCodeBytesExporter = Future<Image?> Function({
   required QrCode qrCode,
   required QrCodeVisualData visualData,
+  required int exportSize,
 });

--- a/lib/tools/qr_code/feature/qr_exporter/qr_exporter_2.dart
+++ b/lib/tools/qr_code/feature/qr_exporter/qr_exporter_2.dart
@@ -10,10 +10,11 @@ abstract interface class NewQrCodeExporter {
   static Future<Image?> generateBytes({
     required QrCode qrCode,
     required QrCodeVisualData visualData,
+    required int exportSize,
   }) async {
     final image = QrImage(qrCode);
     final bytes = await image.toImageAsBytes(
-      size: 600,
+      size: exportSize,
       decoration: PrettyQrDecoration(
         background: visualData.backgroundColor,
         shape: visualData.qrCodeShape,

--- a/lib/tools/qr_code/feature/state/qr_code_state.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.dart
@@ -41,11 +41,15 @@ extension ExportTypeUtils on ExportType {
 @freezed
 @immutable
 class QrCodeState with _$QrCodeState {
+  static const minExportSize = 300;
+  static const maxExportSize = 4000;
+
   const factory QrCodeState({
     required String input,
     required ErrorCorrectionLevel correctionLevel,
     required ExportType exportType,
     required QrCodeVisualData visualData,
+    @Assert('exportDensity > 0') @Default(600) int exportSize,
   }) = _QrCodeState;
 
   const QrCodeState._();
@@ -60,7 +64,7 @@ class QrCodeState with _$QrCodeState {
     visualData: QrCodeVisualData(
       backgroundColor: Color(0xffffffff),
       foregroundColor: Color(0xff000000),
-      shape: QrCodeShape.square,
+      shape: QrCodeShape.smooth,
       paddings: EdgeInsets.zero,
     ),
   );

--- a/lib/tools/qr_code/feature/state/qr_code_state.freezed.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.freezed.dart
@@ -25,6 +25,8 @@ mixin _$QrCodeState {
       throw _privateConstructorUsedError;
   ExportType get exportType => throw _privateConstructorUsedError;
   QrCodeVisualData get visualData => throw _privateConstructorUsedError;
+  @Assert('exportDensity > 0')
+  int get exportSize => throw _privateConstructorUsedError;
 
   /// Serializes this QrCodeState to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -46,7 +48,8 @@ abstract class $QrCodeStateCopyWith<$Res> {
       {String input,
       ErrorCorrectionLevel correctionLevel,
       ExportType exportType,
-      QrCodeVisualData visualData});
+      QrCodeVisualData visualData,
+      @Assert('exportDensity > 0') int exportSize});
 
   $QrCodeVisualDataCopyWith<$Res> get visualData;
 }
@@ -70,6 +73,7 @@ class _$QrCodeStateCopyWithImpl<$Res, $Val extends QrCodeState>
     Object? correctionLevel = null,
     Object? exportType = null,
     Object? visualData = null,
+    Object? exportSize = null,
   }) {
     return _then(_value.copyWith(
       input: null == input
@@ -88,6 +92,10 @@ class _$QrCodeStateCopyWithImpl<$Res, $Val extends QrCodeState>
           ? _value.visualData
           : visualData // ignore: cast_nullable_to_non_nullable
               as QrCodeVisualData,
+      exportSize: null == exportSize
+          ? _value.exportSize
+          : exportSize // ignore: cast_nullable_to_non_nullable
+              as int,
     ) as $Val);
   }
 
@@ -114,7 +122,8 @@ abstract class _$$QrCodeStateImplCopyWith<$Res>
       {String input,
       ErrorCorrectionLevel correctionLevel,
       ExportType exportType,
-      QrCodeVisualData visualData});
+      QrCodeVisualData visualData,
+      @Assert('exportDensity > 0') int exportSize});
 
   @override
   $QrCodeVisualDataCopyWith<$Res> get visualData;
@@ -137,6 +146,7 @@ class __$$QrCodeStateImplCopyWithImpl<$Res>
     Object? correctionLevel = null,
     Object? exportType = null,
     Object? visualData = null,
+    Object? exportSize = null,
   }) {
     return _then(_$QrCodeStateImpl(
       input: null == input
@@ -155,6 +165,10 @@ class __$$QrCodeStateImplCopyWithImpl<$Res>
           ? _value.visualData
           : visualData // ignore: cast_nullable_to_non_nullable
               as QrCodeVisualData,
+      exportSize: null == exportSize
+          ? _value.exportSize
+          : exportSize // ignore: cast_nullable_to_non_nullable
+              as int,
     ));
   }
 }
@@ -166,7 +180,8 @@ class _$QrCodeStateImpl extends _QrCodeState {
       {required this.input,
       required this.correctionLevel,
       required this.exportType,
-      required this.visualData})
+      required this.visualData,
+      @Assert('exportDensity > 0') this.exportSize = 600})
       : super._();
 
   factory _$QrCodeStateImpl.fromJson(Map<String, dynamic> json) =>
@@ -180,10 +195,14 @@ class _$QrCodeStateImpl extends _QrCodeState {
   final ExportType exportType;
   @override
   final QrCodeVisualData visualData;
+  @override
+  @JsonKey()
+  @Assert('exportDensity > 0')
+  final int exportSize;
 
   @override
   String toString() {
-    return 'QrCodeState(input: $input, correctionLevel: $correctionLevel, exportType: $exportType, visualData: $visualData)';
+    return 'QrCodeState(input: $input, correctionLevel: $correctionLevel, exportType: $exportType, visualData: $visualData, exportSize: $exportSize)';
   }
 
   @override
@@ -197,13 +216,15 @@ class _$QrCodeStateImpl extends _QrCodeState {
             (identical(other.exportType, exportType) ||
                 other.exportType == exportType) &&
             (identical(other.visualData, visualData) ||
-                other.visualData == visualData));
+                other.visualData == visualData) &&
+            (identical(other.exportSize, exportSize) ||
+                other.exportSize == exportSize));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, input, correctionLevel, exportType, visualData);
+  int get hashCode => Object.hash(
+      runtimeType, input, correctionLevel, exportType, visualData, exportSize);
 
   /// Create a copy of QrCodeState
   /// with the given fields replaced by the non-null parameter values.
@@ -226,7 +247,8 @@ abstract class _QrCodeState extends QrCodeState {
       {required final String input,
       required final ErrorCorrectionLevel correctionLevel,
       required final ExportType exportType,
-      required final QrCodeVisualData visualData}) = _$QrCodeStateImpl;
+      required final QrCodeVisualData visualData,
+      @Assert('exportDensity > 0') final int exportSize}) = _$QrCodeStateImpl;
   const _QrCodeState._() : super._();
 
   factory _QrCodeState.fromJson(Map<String, dynamic> json) =
@@ -240,6 +262,9 @@ abstract class _QrCodeState extends QrCodeState {
   ExportType get exportType;
   @override
   QrCodeVisualData get visualData;
+  @override
+  @Assert('exportDensity > 0')
+  int get exportSize;
 
   /// Create a copy of QrCodeState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/tools/qr_code/feature/state/qr_code_state.g.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.g.dart
@@ -14,6 +14,7 @@ _$QrCodeStateImpl _$$QrCodeStateImplFromJson(Map<String, dynamic> json) =>
       exportType: $enumDecode(_$ExportTypeEnumMap, json['exportType']),
       visualData:
           QrCodeVisualData.fromJson(json['visualData'] as Map<String, dynamic>),
+      exportSize: (json['exportSize'] as num?)?.toInt() ?? 600,
     );
 
 Map<String, dynamic> _$$QrCodeStateImplToJson(_$QrCodeStateImpl instance) =>
@@ -23,6 +24,7 @@ Map<String, dynamic> _$$QrCodeStateImplToJson(_$QrCodeStateImpl instance) =>
           _$ErrorCorrectionLevelEnumMap[instance.correctionLevel]!,
       'exportType': _$ExportTypeEnumMap[instance.exportType]!,
       'visualData': instance.visualData,
+      'exportSize': instance.exportSize,
     };
 
 const _$ErrorCorrectionLevelEnumMap = {
@@ -62,7 +64,7 @@ Map<String, dynamic> _$$QrCodeVisualDataImplToJson(
     };
 
 const _$QrCodeShapeEnumMap = {
+  QrCodeShape.smooth: 'smooth',
   QrCodeShape.square: 'square',
   QrCodeShape.circle: 'circle',
-  QrCodeShape.smooth: 'smooth',
 };

--- a/lib/tools/qr_code/ui/qr_code_output.dart
+++ b/lib/tools/qr_code/ui/qr_code_output.dart
@@ -251,6 +251,13 @@ class _ExportSizeWidgetState extends State<_ExportSizeWidget> {
             suffixMode: OverlayVisibilityMode.always,
           ),
         ),
+        const SizedBox(width: 8),
+        HintButton(
+          hint: t.qrCode.exportSizeHint(
+            from: QrCodeState.minExportSize,
+            to: QrCodeState.maxExportSize,
+          ),
+        )
       ],
     );
   }

--- a/lib/tools/qr_code/ui/qr_code_screen.dart
+++ b/lib/tools/qr_code/ui/qr_code_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:mini_tea_flutter/mini_tea_flutter.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';

--- a/lib/tools/qr_code/ui/qr_code_screen.dart
+++ b/lib/tools/qr_code/ui/qr_code_screen.dart
@@ -8,6 +8,7 @@ import 'package:pretty_qr_code/pretty_qr_code.dart';
 import 'package:provider/provider.dart';
 
 import '../../../common/padding.dart';
+import '../../../common/ui/hint_button.dart';
 import '../../../common/ui/input_text.dart';
 import '../../../common/ui/mini_color_picker.dart';
 import '../../../i18n/strings.g.dart';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to customize the export size (in pixels) when exporting QR codes.
  - Introduced a new input field in the QR code export UI for specifying export size.
- **Improvements**
  - The export process now respects the user-defined export size for PNG, JPG, and SVG formats.
  - Default QR code shape changed to "smooth" for new QR codes.
- **Localization**
  - Added new UI strings for export size options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->