### PR TITLE
#246: Hide SVG export type

### DIFF
--- a/lib/tools/qr_code/feature/qr_code_effect_handler.dart
+++ b/lib/tools/qr_code/feature/qr_code_effect_handler.dart
@@ -83,14 +83,6 @@ final class QrCodeEffectHandler
           await file.writeAsBytes(content);
         }
         break;
-      case ExportType.svg:
-        final content = generateQrCodeSvg(
-          effect.code,
-          effect.visualData,
-          effect.exportSize,
-        );
-        await file.writeAsString(content);
-        break;
     }
   }
 

--- a/lib/tools/qr_code/feature/state/qr_code_state.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.dart
@@ -18,7 +18,6 @@ enum ErrorCorrectionLevel {
 enum ExportType {
   png,
   jpg,
-  svg,
 }
 
 extension ErrorCorrectionLevelUtils on ErrorCorrectionLevel {
@@ -34,7 +33,6 @@ extension ExportTypeUtils on ExportType {
   String get extension => switch (this) {
         ExportType.png => 'png',
         ExportType.jpg => 'jpg',
-        ExportType.svg => 'svg',
       };
 }
 

--- a/lib/tools/qr_code/feature/state/qr_code_state.g.dart
+++ b/lib/tools/qr_code/feature/state/qr_code_state.g.dart
@@ -37,7 +37,6 @@ const _$ErrorCorrectionLevelEnumMap = {
 const _$ExportTypeEnumMap = {
   ExportType.png: 'png',
   ExportType.jpg: 'jpg',
-  ExportType.svg: 'svg',
 };
 
 _$QrCodeVisualDataImpl _$$QrCodeVisualDataImplFromJson(

--- a/lib/tools/qr_code/ui/qr_code_extensions.dart
+++ b/lib/tools/qr_code/ui/qr_code_extensions.dart
@@ -20,7 +20,6 @@ extension on ExportType {
     return switch (this) {
       ExportType.png => t.qrCode.exportType.png,
       ExportType.jpg => t.qrCode.exportType.jpg,
-      ExportType.svg => t.qrCode.exportType.svg,
     };
   }
 }

--- a/lib/tools/qr_code/ui/qr_code_output.dart
+++ b/lib/tools/qr_code/ui/qr_code_output.dart
@@ -21,7 +21,6 @@ class _OutputSide extends StatelessWidget {
         Center(child: _QrCodeWidget()),
         SizedBox(height: 8),
         _ExportQrLine(),
-        Center(child: _SvgWarning()),
         SizedBox(height: 4),
         Center(child: _TestQrWarning()),
       ],
@@ -301,34 +300,6 @@ class _QrCodeWidget extends StatelessWidget {
             ),
           ),
         );
-      },
-    );
-  }
-}
-
-class _SvgWarning extends StatelessWidget {
-  const _SvgWarning();
-
-  @override
-  Widget build(BuildContext context) {
-    final t = Translations.of(context);
-
-    return FeatureBuilder<QrCodeFeature, QrCodeState>(
-      buildWhen: (prev, curr) =>
-          prev.exportType != curr.exportType ||
-          prev.visualData != curr.visualData,
-      builder: (context, state) {
-        if (state.exportType == ExportType.svg &&
-            state.visualData.shape != QrCodeShape.square) {
-          return DefaultTextStyle.merge(
-            style: TextStyle(
-              color: Colors.red.shade300,
-            ),
-            child: Text(t.qrCode.shapes.svgWarning),
-          );
-        }
-
-        return const SizedBox();
       },
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed support for exporting QR codes in SVG format.
  - The SVG export option is no longer available in the export menu.
  - The warning message related to SVG export and QR code shape compatibility has been removed from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->